### PR TITLE
Enhanced and fixed the Grafana dashboards

### DIFF
--- a/grafana/dashboard-environmental-analysis.json
+++ b/grafana/dashboard-environmental-analysis.json
@@ -1,0 +1,222 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "humidity"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pressure"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "pressurehpa"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"temperature\" or r._field == \"humidity\" or r._field == \"pressure\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> yield(name: \"mean\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Environmental Trends",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "series": [
+          {
+            "type": "scatter"
+          }
+        ],
+        "show": {
+          "legend": false
+        }
+      },
+      "targets": [
+        {
+          "query": "t_hum = from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"temperature\" or r._field == \"humidity\")\n  |> aggregateWindow(every: 10m, fn: mean)\n  |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\nt_hum\n  |> map(fn: (r) => ({ temp: r.temperature, hum: r.humidity }))",
+          "refId": "A"
+        }
+      ],
+      "title": "Temperature vs. Humidity",
+      "type": "xychart"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: -30d, stop: now())\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> map(fn: (r) => ({ r with hour: string(v: hour(t: r._time)) }))\n  |> group(columns: [\"hour\"])\n  |> mean()\n  |> sort(columns: [\"hour\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Hourly Average Temperature (30d)",
+      "type": "barchart"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: -30d, stop: now())\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> map(fn: (r) => ({ r with weekday: string(v: weekDay(t: r._time)) }))\n  |> group(columns: [\"weekday\"])\n  |> mean()\n  |> sort(columns: [\"weekday\"])",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Average Humidity (30d)",
+      "type": "barchart"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "ruuvi",
+    "weather",
+    "environmental",
+    "analysis"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Environmental Analysis",
+  "uid": "ruuvi-environmental-analysis",
+  "version": 1
+}

--- a/grafana/dashboard-forecast-accuracy-analysis.json
+++ b/grafana/dashboard-forecast-accuracy-analysis.json
@@ -151,19 +151,19 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
           "refId": "B"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
           "refId": "C"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"48h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"48h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"48h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"48h\")",
           "refId": "D"
         }
       ],
@@ -242,15 +242,15 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"rmse\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"rmse\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"rmse\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"rmse\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
           "refId": "B"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"rmse\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"rmse\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
           "refId": "C"
         }
       ],
@@ -329,15 +329,15 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
           "refId": "B"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
           "refId": "C"
         }
       ],
@@ -416,15 +416,15 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"signed_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"signed_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"1h\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"signed_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"signed_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"6h\")",
           "refId": "B"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"signed_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"signed_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"24h\")",
           "refId": "C"
         }
       ],
@@ -484,7 +484,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> mean()\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> mean()\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
@@ -544,7 +544,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> mean()\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> mean()\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
@@ -604,7 +604,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> mean()\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> mean()\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
@@ -664,7 +664,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"pressure\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> mean()\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"mae\")\n  |> filter(fn: (r) => r.metric == \"pressure\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> mean()\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],

--- a/grafana/dashboard-live-weather-comparison.json
+++ b/grafana/dashboard-live-weather-comparison.json
@@ -151,19 +151,19 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"actual\")",
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"actual\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"1h_forecast\")",
+          "query": "from(bucket: \"weather_forecasts\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"1h_forecast\")",
           "refId": "B"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"6h_forecast\")",
+          "query": "from(bucket: \"weather_forecasts\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"6h_forecast\")",
           "refId": "C"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"24h_forecast\")",
+          "query": "from(bucket: \"weather_forecasts\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"24h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"24h_forecast\")",
           "refId": "D"
         }
       ],
@@ -242,15 +242,15 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"actual\")",
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"actual\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"1h_forecast\")",
+          "query": "from(bucket: \"weather_forecasts\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"1h_forecast\")",
           "refId": "B"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"6h_forecast\")",
+          "query": "from(bucket: \"weather_forecasts\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"6h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"6h_forecast\")",
           "refId": "C"
         }
       ],
@@ -329,11 +329,11 @@
       },
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"pressure\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"actual\")",
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"pressure\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"actual\")",
           "refId": "A"
         },
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"pressure\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"1h_forecast\")",
+          "query": "from(bucket: \"weather_forecasts\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecasts\")\n  |> filter(fn: (r) => r._field == \"pressure\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"1h_forecast\")",
           "refId": "B"
         }
       ],
@@ -393,7 +393,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"absolute_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"absolute_error\")\n  |> filter(fn: (r) => r.metric == \"temperature\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
@@ -453,7 +453,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "query": "from(bucket: \"ruuvi\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"absolute_error\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"weather_forecast_errors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_forecast_errors\")\n  |> filter(fn: (r) => r._field == \"absolute_error\")\n  |> filter(fn: (r) => r.metric == \"humidity\")\n  |> filter(fn: (r) => r.forecast_horizon == \"1h\")\n  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],

--- a/grafana/dashboard-sensor-diagnostics.json
+++ b/grafana/dashboard-sensor-diagnostics.json
@@ -1,0 +1,253 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2.5
+              },
+              {
+                "color": "green",
+                "value": 2.8
+              }
+            ]
+          },
+          "unit": "volt"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^battery_voltage$/",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"battery_voltage\")\n  |> last()",
+          "refId": "A"
+        }
+      ],
+      "title": "Battery Voltage",
+      "type": "gauge"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "auto"
+          },
+          "mappings": [],
+          "unit": "dBm"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"rssi\")\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"mean_rssi\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Signal Strength (RSSI)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.0",
+      "targets": [
+        {
+          "query": "from(bucket: \"ruuvi_sensors\")\n  |> range(start: -5m, stop: now())\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> group(columns: [\"sensor_mac\"])\n  |> count()\n  |> map(fn: (r) => ({_value: r._value / 5.0}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg. Data Points per Minute (last 5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "time:YYYY-MM-DD HH:mm:ss"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "query": "last_values = from(bucket: \"ruuvi_sensors\")\n  |> range(start: -1d, stop: now())\n  |> filter(fn: (r) => r._measurement == \"weather_sensors\")\n  |> filter(fn: (r) => r._field == \"battery_voltage\" or r._field == \"rssi\")\n  |> last()\n  |> group(columns: [\"sensor_mac\"])\n\nlast_values\n  |> pivot(rowKey:[\"sensor_mac\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "title": "Sensor Health Overview",
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "ruuvi",
+    "sensor",
+    "diagnostics",
+    "health"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sensor Diagnostics",
+  "uid": "ruuvi-sensor-diagnostics",
+  "version": 1
+}


### PR DESCRIPTION
1.  **Corrected Data Sources:** I found that the existing dashboards for live weather comparison and forecast accuracy analysis were querying an incorrect InfluxDB bucket named "ruuvi". I've corrected this to use the proper buckets as described in the documentation: "ruuvi_sensors", "weather_forecasts", and "weather_forecast_errors". This ensures that the dashboards now display the correct data.

2.  **New Dashboards:** I also added two new dashboards to provide more insights into the collected data:
    *   `dashboard-environmental-analysis.json`: This dashboard provides an overview of the environmental data from the Ruuvi sensors, including trends and correlations between temperature, humidity, and pressure.
    *   `dashboard-sensor-diagnostics.json`: This dashboard helps you monitor the health and performance of the Ruuvi sensors, including battery voltage, signal strength (RSSI), and data transmission frequency.